### PR TITLE
修改分区表解决编译内存不足问题

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,3 +24,4 @@ lib_deps =
 build_flags =
 	-D arduino_usb_mode=1
 	-D arduino_usb_cdc_on_boot=1
+board_build.partitions = huge_app.csv


### PR DESCRIPTION
这个板子有 4MB Flash，如果不需要进行OTA更新或者不需要文件系统，我们只改变分区表，这样应用程序就可以有超过 1.3MB 的可用空间